### PR TITLE
Fix building with ESP8266.

### DIFF
--- a/ESPRandom.h
+++ b/ESPRandom.h
@@ -6,7 +6,11 @@
 #define ESPRandom_h
 
 #include "Arduino.h"
+#ifdef ESP32
 #include "WiFi.h"
+#elif defined(ESP8266)
+#include "ESP8266WiFi.h"
+#endif
 
 class ESPRandom {
  public:


### PR DESCRIPTION
For ESP8266 we have to include ESP8266WiFi.h instead of WiFi.h. This PR fixes that.
Thanks for the library!