### PR TITLE
Added std::vector as include 

### DIFF
--- a/ESPRandom.h
+++ b/ESPRandom.h
@@ -9,6 +9,7 @@
 #include <WiFi.h>
 
 #include <chrono>
+#include <vector>
 
 class ESPRandom {
  public:


### PR DESCRIPTION
Newer versions of the Arduino core for PlatformIO (and potentially other frameworks) had issues with vector not being explicitly included in the header. 
Simply adding the std::vector include solves this issue.